### PR TITLE
build: Make script executable

### DIFF
--- a/.github/workflows/docker-build-on-merge.yml
+++ b/.github/workflows/docker-build-on-merge.yml
@@ -36,5 +36,5 @@ jobs:
               run: |
                   #   lodexdocker build -t parmentf/teeft:latest services/terms-teeft
                   #   docker push parmentf/teeft:latest
-                  #   chmod +x ${{ github.workspace }}/.github/workflows/build-and-push.sh
+                  chmod +x ${{ github.workspace }}/.github/workflows/build-and-push.sh
                   ${{ github.workspace }}/.github/workflows/build-and-push.sh


### PR DESCRIPTION
As the shell failed, with status -1.
Maybe it was that the script was not executable (saw that in lodex repository).